### PR TITLE
Added logiq monitoring link

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Streaming Search on Tweets: Storm, Elasticsearch, and Redis
 * [Structured logging with ELK - part 1](http://engineering.laterooms.com/structured-logging-with-elk-part-1/)
 * [Search for :yum: Emoji with Elasticsearch :mag_right:](http://jolicode.com/blog/search-for-emoji-with-elasticsearch)
 * [Complete Guide to the ELK Stack](http://logz.io/learn/complete-guide-elk-stack/)
-* [logiq](https://github.com/sloniki/logiq) -  - Simple WebUI Monitoring Tool for Logstash ver. 5 and up
+* [logiq](https://github.com/sloniki/logiq) - Simple WebUI Monitoring Tool for Logstash ver. 5.0 and up
 
 ## Videos
 ### Overviews


### PR DESCRIPTION
Please add the link to the new simple monitoring tool. It is a JavaScript page which uses new Logstash monitoring API.